### PR TITLE
Add test_dirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ use({
           cwd = function(path)
             return vim.fn.getcwd()
           end,
+          test_dirs = { "__tests__" },
         }),
       }
     })
@@ -70,6 +71,7 @@ vim.api.nvim_set_keymap("n", "<leader>tw", "<cmd>lua require('neotest').run.run(
 
 If you want to allow to `neotest-jest` to discover parameterized tests you need to enable flag
 `jest_test_discovery` in config setup:
+
 ```lua
 require('neotest').setup({
   ...,
@@ -81,7 +83,9 @@ require('neotest').setup({
   }
 })
 ```
+
 Its also recommended to disable `neotest` `discovery` option like this:
+
 ```lua
 require("neotest").setup({
 	...,
@@ -90,11 +94,13 @@ require("neotest").setup({
 	},
 })
 ```
+
 because `jest_test_discovery` runs `jest` command on file to determine
 what tests are inside the file. If `discovery` would be enabled then `neotest-jest`
 would spawn a lot of procesees.
 
 ### Monorepos
+
 If you have a monorepo setup, you might have to do a little more configuration, especially if
 you have different jest configurations per package.
 
@@ -121,6 +127,15 @@ cwd = function()
   end
   return vim.fn.getcwd()
 end
+```
+
+The default directory name to look for tests is `__tests__`. For custom names use `test_dirs`
+
+```lua
+require("neotest").setup({
+	...,
+        test_dirs = { "__tests__", "tests" },
+})
 ```
 
 ## :gift: Contributing


### PR DESCRIPTION
The default directory name to look for tests is __tests__. For custom names use test_dirs

require("neotest").setup({
	...,
        test_dirs = { "__tests__", "tests" },
})

